### PR TITLE
feat: add GitHub Actions workflow for research automation

### DIFF
--- a/.github/workflows/researcher.yml
+++ b/.github/workflows/researcher.yml
@@ -1,0 +1,56 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [opened]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '/research')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '/research')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '/research')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '/research') || contains(github.event.issue.title, '/research'))) ||
+      (github.event_name == 'pull_request' && (github.event.action == 'opened' || contains(github.event.pull_request.body, '/research')))
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Research
+        id: claude
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GH_PAT }}
+          trigger_phrase: "/research"
+          allowed_tools: Bash   
+          custom_instructions: |
+            1. Research the defined subject
+            2. Use the specs/extractors extract information from the research as json
+            3. Save the extractor artifacts to ./research/<subject>/<spec>.json
+
+      - name: Report
+        id: report
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GH_PAT }}
+          trigger_phrase: "/research"
+          allowed_tools: Bash          
+          custom_instructions: |
+            1. Collect the json files from ./research/<subject>
+            2. Compile the collected json into a markdown formatted report
+            3. Save the report to ./research/<subject>/report.md
+


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow named "Claude Code" to automate research tasks. The workflow triggers on various GitHub events such as issue comments, pull request review comments, issues, and pull requests. It uses the "anthropics/claude-code-action" to perform research based on a trigger phrase "/research". The research results are extracted into JSON files and compiled into a markdown report. The workflow is configured to run on the latest Ubuntu environment and requires specific API keys and tokens for execution.

## Summary by Sourcery

Add a GitHub Actions workflow named “Claude Code” that automates research tasks whenever the "/research" trigger appears in issues, pull requests, or comments by extracting data into JSON artifacts and compiling them into markdown reports.

New Features:
- Introduce "Claude Code" workflow triggered on issue comments, pull request comments, reviews, issues, and pull requests containing "/research"
- Use anthropics/claude-code-action to perform research and save extractor outputs as JSON
- Generate a consolidated markdown report from the extracted JSON data