### PR TITLE
feat(workflow): update researcher workflow

### DIFF
--- a/.github/workflows/researcher.yml
+++ b/.github/workflows/researcher.yml
@@ -1,4 +1,4 @@
-name: Claude Code
+name: Researcher
 
 on:
   issue_comment:
@@ -28,8 +28,8 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Research
-        id: claude
+      - name: Researcher
+        id: research
         uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -38,19 +38,9 @@ jobs:
           allowed_tools: Bash   
           custom_instructions: |
             1. Research the defined subject
-            2. Use the specs/extractors extract information from the research as json
-            3. Save the extractor artifacts to ./research/<subject>/<spec>.json
-
-      - name: Report
-        id: report
-        uses: anthropics/claude-code-action@beta
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.GH_PAT }}
-          trigger_phrase: "/research"
-          allowed_tools: Bash          
-          custom_instructions: |
-            1. Collect the json files from ./research/<subject>
-            2. Compile the collected json into a markdown formatted report
-            3. Save the report to ./research/<subject>/report.md
-
+            2. Only use the specs specified by the user.
+            3. If no specs are specified ask the user to clarify before proceeding.
+            4. Use the json schema specs to extract information from the research as json
+            5. Save the extractor artifacts to ./research/<subject>/<spec>.json
+            6. Use the collected json to generate a markdown formatted report
+            7. Save the report to ./research/<subject>/report.md


### PR DESCRIPTION
- Rename workflow from "Claude Code" to "Researcher"
- Modify job names and IDs for clarity
- Simplify research process by removing redundant steps
- Ensure user-specified specs are used for research
- Generate markdown report directly from collected JSON data

## Summary by Sourcery

Rename the GitHub Actions workflow to Researcher, simplify and consolidate the research and report steps into a single job, enforce user-specified specs, and generate markdown reports directly from JSON artifacts

Enhancements:
- Rename the workflow from Claude Code to Researcher, updating job names and IDs
- Consolidate report generation into the research job and remove the separate report step
- Enforce user-specified specs for data extraction and prompt for clarification if none are provided
- Use JSON schema specs to extract research data and generate markdown reports in one pass