### PR TITLE
feat: add meeting agenda JSON schema

### DIFF
--- a/specs/artifacts/meeting_agenda.example.json
+++ b/specs/artifacts/meeting_agenda.example.json
@@ -1,0 +1,85 @@
+{
+  "title": "Q4 Planning Meeting",
+  "date": "2025-08-15T14:00:00Z",
+  "duration": 90,
+  "location": "Conference Room A / Zoom: https://company.zoom.us/j/123456789",
+  "organizer": "Sarah Johnson",
+  "attendees": [
+    {
+      "name": "Sarah Johnson",
+      "role": "Product Manager",
+      "required": true
+    },
+    {
+      "name": "Mike Chen",
+      "role": "Engineering Lead",
+      "required": true
+    },
+    {
+      "name": "Anna Rodriguez",
+      "role": "Designer",
+      "required": false
+    }
+  ],
+  "objectives": [
+    "Define Q4 product roadmap priorities",
+    "Align on resource allocation",
+    "Identify potential risks and mitigation strategies"
+  ],
+  "agenda_items": [
+    {
+      "title": "Welcome and Introductions",
+      "description": "Brief introductions and meeting overview",
+      "presenter": "Sarah Johnson",
+      "duration": 10,
+      "type": "update"
+    },
+    {
+      "title": "Q3 Retrospective",
+      "description": "Review Q3 achievements and lessons learned",
+      "presenter": "Mike Chen",
+      "duration": 20,
+      "type": "review",
+      "materials": ["Q3 Sprint Report", "Customer Feedback Summary"]
+    },
+    {
+      "title": "Q4 Feature Prioritization",
+      "description": "Discuss and prioritize features for Q4 development",
+      "presenter": "Sarah Johnson",
+      "duration": 30,
+      "type": "decision",
+      "materials": ["Feature Request Backlog", "Market Analysis Report"]
+    },
+    {
+      "title": "Resource Planning",
+      "description": "Review team capacity and resource requirements",
+      "presenter": "Mike Chen",
+      "duration": 20,
+      "type": "discussion"
+    },
+    {
+      "title": "Next Steps and Action Items",
+      "description": "Define clear action items and owners",
+      "presenter": "Sarah Johnson",
+      "duration": 10,
+      "type": "decision"
+    }
+  ],
+  "preparation_notes": [
+    "Review Q3 performance metrics",
+    "Come prepared with top 3 feature requests from your team",
+    "Review resource availability for Q4"
+  ],
+  "follow_up_items": [
+    {
+      "item": "Finalize Q4 roadmap document",
+      "assignee": "Sarah Johnson",
+      "due_date": "2025-08-18"
+    },
+    {
+      "item": "Create detailed technical specifications",
+      "assignee": "Mike Chen",
+      "due_date": "2025-08-22"
+    }
+  ]
+}

--- a/specs/artifacts/meeting_agenda.schema.json
+++ b/specs/artifacts/meeting_agenda.schema.json
@@ -1,0 +1,129 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MeetingAgenda",
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string",
+      "description": "Title of the meeting."
+    },
+    "date": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Date and time of the meeting (ISO 8601 format)."
+    },
+    "duration": {
+      "type": "integer",
+      "description": "Duration of the meeting in minutes.",
+      "minimum": 1
+    },
+    "location": {
+      "type": "string",
+      "description": "Meeting location or virtual meeting link."
+    },
+    "organizer": {
+      "type": "string",
+      "description": "Person organizing the meeting."
+    },
+    "attendees": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Attendee name."
+          },
+          "role": {
+            "type": "string",
+            "description": "Attendee role or title."
+          },
+          "required": {
+            "type": "boolean",
+            "description": "Whether attendance is required.",
+            "default": false
+          }
+        },
+        "required": ["name"]
+      },
+      "description": "List of meeting attendees."
+    },
+    "objectives": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Meeting objectives or goals."
+    },
+    "agenda_items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Agenda item title."
+          },
+          "description": {
+            "type": "string",
+            "description": "Detailed description of the agenda item."
+          },
+          "presenter": {
+            "type": "string",
+            "description": "Person presenting this item."
+          },
+          "duration": {
+            "type": "integer",
+            "description": "Allocated time for this item in minutes.",
+            "minimum": 1
+          },
+          "type": {
+            "type": "string",
+            "enum": ["discussion", "presentation", "decision", "update", "brainstorm", "review"],
+            "description": "Type of agenda item."
+          },
+          "materials": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Pre-reading materials or documents needed."
+          }
+        },
+        "required": ["title"]
+      },
+      "description": "List of agenda items to be covered."
+    },
+    "preparation_notes": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Notes on what attendees should prepare beforehand."
+    },
+    "follow_up_items": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "item": {
+            "type": "string",
+            "description": "Follow-up item description."
+          },
+          "assignee": {
+            "type": "string",
+            "description": "Person responsible for follow-up."
+          },
+          "due_date": {
+            "type": "string",
+            "format": "date",
+            "description": "Due date for follow-up (ISO 8601 date format)."
+          }
+        },
+        "required": ["item"]
+      },
+      "description": "Items that require follow-up after the meeting."
+    }
+  },
+  "required": ["title", "date", "agenda_items"]
+}


### PR DESCRIPTION
Add comprehensive meeting agenda JSON schema to spec artifacts directory.

## Changes
- `meeting_agenda.schema.json`: Complete schema with meeting details, attendees, agenda items, and follow-up tracking
- `meeting_agenda.example.json`: Example Q4 planning meeting demonstrating all schema features

The schema enables AI agents to structure and process meeting agendas consistently across the pAI system.

Fixes #37

Generated with [Claude Code](https://claude.ai/code)